### PR TITLE
Rework the filesystem implementation.

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ['1.18', '1.19']
+        go-version: ['1.19']
         os: ['ubuntu-latest']
     steps:
     - name: Install Go ${{ matrix.go-version }}

--- a/cmd/ffuse/ffuse.go
+++ b/cmd/ffuse/ffuse.go
@@ -20,43 +20,59 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 
-	"github.com/creachadair/ffs/blob"
-	"github.com/creachadair/ffs/file"
-	"github.com/creachadair/ffstools/ffs/config"
-	"github.com/creachadair/ffuse"
-
 	"github.com/seaweedfs/fuse"
-	"github.com/seaweedfs/fuse/fs"
 )
 
 var (
-	storeAddr   = flag.String("store", os.Getenv("FFS_STORE"), "Blob storage address (required)")
-	mountPoint  = flag.String("mount", "", "Path of mount point (required)")
-	doReadOnly  = flag.Bool("read-only", false, "Mount the filesystem as read-only")
-	doDebugLog  = flag.Bool("debug", false, "Enable debug logging (warning: noisy)")
-	rootKey     = flag.String("root", "", "Storage key of root pointer")
-	autoFlush   = flag.Duration("auto-flush", 0, "Automatically flush the root at this interval")
-	doSigFlush  = flag.Bool("sig-flush", false, "If true, SIGUSR1 will trigger a root flush")
-	doSigUpdate = flag.Bool("sig-update", false, "If true, SIGUSR2 will trigger a root reload")
+	serveAddr = flag.String("listen", "", "Status service address")
+
+	svc = &Service{
+		MountOptions: []fuse.MountOption{
+			fuse.FSName("ffs"),
+			fuse.Subtype("ffs"),
+			fuse.VolumeName("FFS"),
+			fuse.NoAppleDouble(),
+			fuse.MaxReadahead(1 << 16),
+		},
+	}
 )
 
 func init() {
+	flag.StringVar(&svc.StoreSpec, "store", os.Getenv("FFS_STORE"), "Blob storage address (required)")
+	flag.StringVar(&svc.MountPath, "mount", "", "Path of mount point (required)")
+	flag.BoolVar(&svc.ReadOnly, "read-only", false, "Mount the filesystem as read-only")
+	flag.BoolVar(&svc.DebugLog, "debug", false, "Enable debug logging (warning: noisy)")
+	flag.StringVar(&svc.RootKey, "root", "", "Storage key of root pointer")
+	flag.DurationVar(&svc.AutoFlush, "auto-flush", 0, "Automatically flush the root at this interval")
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage: %[1]s [-read-only] -store addr -mount path -root key[/path...]
 
-Mount a FFS filesystem via FUSE at the specified -mount path, using the blob
-store described by addr. The starting point for the mount may be the name of a
+Mount a FFS filesystem via FUSE at the specified -mount path, using the store
+described by addr. The starting point for the mount may be the name of a
 root pointer, or a path relative to a root pointer, or a specific storage key
 prefixed by "@".
 
 If -store is not set, the FFS_STORE environment variable is used as a default
 if it is defined; otherwise the default from the FFS config file is used or an
 error is reported.
+
+If -listen is set, an HTTP service is exposed at that address which supports
+the following operations:
+
+   GET /status     -- return a JSON blob of filesystem status
+   GET /flush      -- as /status, but also flushes the root to storage
+   PUT /root/:key  -- update the filesystem root to the specified key
+
+Updating the filesystem changes what is visible through the mount point.
+You can effect a "reload" of the filesystem contents by putting the same value
+the filesystem was started with.
 
 Options:
 `, filepath.Base(os.Args[0]))
@@ -68,161 +84,27 @@ func main() {
 	flag.Parse()
 	log.SetPrefix("[ffuse] ")
 
-	switch {
-	case *mountPoint == "":
-		log.Fatal("You must set a non-empty -mount path")
-	case *rootKey == "":
-		log.Fatal("You must set a non-empty -root pointer key")
-	}
-
-	cfg, err := config.Load(config.Path())
-	if err != nil {
-		log.Fatalf("Loading configuration: %v", err)
-	}
-	if *storeAddr != "" {
-		cfg.DefaultStore = *storeAddr
-	}
-	if *doDebugLog {
-		cfg.EnableDebugLogging = true
-		fuse.Debug = func(arg any) {
-			log.Printf("FUSE: %v", arg)
-		}
-	}
-
 	ctx := context.Background()
-	cas, err := cfg.OpenStore()
-	if err != nil {
-		log.Fatalf("Opening blob store: %v", err)
-	}
-	defer blob.CloseStore(ctx, cas)
+	svc.Init(ctx)
 
-	pi, err := config.OpenPath(ctx, cas, *rootKey)
-	if err != nil {
-		log.Fatalf("Loading root path: %v", err)
-	}
-	if pi.Root != nil {
-		log.Printf("Loaded filesystem from %q (%x)", pi.RootKey, pi.FileKey)
-		if pi.Root.Description != "" {
-			log.Printf("| Description: %q", pi.Root.Description)
-		}
-	} else {
-		log.Printf("Loaded filesystem at %x (no root pointer)", pi.FileKey)
+	if *serveAddr != "" {
+		log.Printf("Starting status service at %q...", *serveAddr)
+		go func() {
+			if err := http.ListenAndServe(*serveAddr, svc.Status); err != nil {
+				log.Fatalf("HTTP service failed: %v", err)
+			}
+		}()
 	}
 
-	// Mount the filesystem and serve from our filesystem root.
-	opts := []fuse.MountOption{
-		fuse.FSName("ffs"),
-		fuse.Subtype("ffs"),
-		fuse.VolumeName("FFS"),
-		fuse.NoAppleDouble(),
-		fuse.MaxReadahead(1 << 16),
-	}
-	if *doReadOnly {
-		opts = append(opts, fuse.ReadOnly())
-	}
-
-	c, err := fuse.Mount(*mountPoint, opts...)
-	if err != nil {
+	if err := svc.Mount(); err != nil {
 		log.Fatalf("Mount failed: %v", err)
 	}
 
-	// Set up auto-flush if it was requested.
-	var fsOpts *ffuse.Options
-	if *autoFlush > 0 {
-		fsOpts = &ffuse.Options{
-			AutoFlushInterval: *autoFlush,
-			OnAutoFlush: func(f *file.File, err error) {
-				if err == nil {
-					_, err = pi.Flush(ctx)
-				}
-				if err != nil {
-					log.Printf("WARNING: Auto-flushing failed: %v", err)
-				} else {
-					log.Print("Root auto-flushed to storage: OK")
-				}
-			},
-		}
-		log.Printf("Enabling auto-flush every %v", *autoFlush)
-		if *doReadOnly {
-			log.Print("NOTE: It does not make sense to -auto-flush with -read-only")
-		}
-	}
+	// Set up a context to propagate signals to the serving loop.
+	rctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT)
+	err := svc.Run(rctx)
+	cancel()
 
-	server := fs.New(c, nil)
-	fsys := ffuse.New(pi.File, server, fsOpts)
-	done := make(chan error, 1)
-	go func() { defer close(done); done <- fs.Serve(c, fsys) }()
-
-	// Wait for the server to come up, and check that it successfully mounted.
-	<-c.Ready
-	if err := c.MountError; err != nil {
-		c.Close()
-		log.Fatalf("Mount error: %v", err)
-	}
-
-	// Block indefinitely to let the server run, but handle interrupt and
-	// termination signals to unmount and flush the root.
-	handleSignals(ctx, done, cas, pi, fsys)
-
-	if err := c.Close(); err != nil {
-		log.Printf("WARNING: closing fuse connection failed: %v", err)
-	} else {
-		log.Print("Closed fuse connection")
-	}
-	if !*doReadOnly {
-		rk, err := pi.Flush(ctx)
-		if err != nil {
-			log.Fatalf("Flushing file data: %v", err)
-		}
-		fmt.Printf("%x\n", rk)
-	}
-}
-
-func handleSignals(ctx context.Context, done <-chan error, cas blob.CAS, pi *config.PathInfo, fsys *ffuse.FS) {
-	sig := make(chan os.Signal, 4)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
-	for {
-		select {
-		case err := <-done:
-			log.Printf("Server exited: %v", err)
-			return
-
-		case s := <-sig:
-			log.Printf("Received signal: %v", s)
-			switch s {
-			case syscall.SIGUSR1:
-				if !*doSigFlush {
-					log.Print("- Ignoring signal because -sig-flush is false")
-					continue
-				}
-				if _, err := pi.Flush(ctx); err != nil {
-					log.Printf("WARNING: Root flush failed; %v", err)
-				} else {
-					log.Print("Root flushed to storage: OK")
-				}
-				continue
-
-			case syscall.SIGUSR2:
-				if !*doSigUpdate {
-					log.Print("- Ignoring signal because -sig-update is false")
-					continue
-				}
-				npi, err := config.OpenPath(ctx, cas, *rootKey)
-				if err != nil {
-					log.Printf("WARNING: Reloading filesystem root failed: %v", err)
-				} else {
-					*pi = *npi
-					fsys.Update(pi.File)
-					log.Print("Reloaded filesystem root: OK")
-				}
-				continue
-			}
-
-			log.Printf("Unmounting %q", *mountPoint)
-			if err := fuse.Unmount(*mountPoint); err != nil {
-				log.Printf("WARNING: unmount failed: %v", err)
-			}
-		}
-		return
-	}
+	log.Printf("Server exited: %v", err)
+	svc.Shutdown(ctx)
 }

--- a/cmd/ffuse/service.go
+++ b/cmd/ffuse/service.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/creachadair/ffs/blob"
+	"github.com/creachadair/ffs/file"
+	"github.com/creachadair/ffstools/ffs/config"
+	"github.com/creachadair/ffuse"
+	"github.com/seaweedfs/fuse"
+	"github.com/seaweedfs/fuse/fs"
+)
+
+// Service holds the state of the mounted filesystem.
+type Service struct {
+	MountPath string        // path of mount point
+	RootKey   string        // root or file key
+	StoreSpec string        // blob store spec
+	ReadOnly  bool          // whether the mount is read-only
+	DebugLog  bool          // whether to enable debug logging
+	AutoFlush time.Duration // auto-flush interval (0=disabled)
+
+	// Fuse library settings.
+	MountOptions []fuse.MountOption
+	FileServer   *fs.Server
+	Conn         *fuse.Conn
+
+	// Filesystem settings.
+	Options ffuse.Options
+	FS      *ffuse.FS
+	Status  *http.ServeMux
+
+	// Blob storage.
+	Config *config.Settings
+	Store  blob.CAS
+	Path   atomic.Pointer[config.PathInfo]
+}
+
+// Init checks the settings, and loads the initial filesystem state from the
+// specified blob store. It terminates the process if any of these steps fail.
+func (s *Service) Init(ctx context.Context) {
+	var err error
+
+	// Check flags for consistency.
+	if s.MountPath == "" {
+		log.Fatal("You must set a non-empty -mount path")
+	} else if s.RootKey == "" {
+		log.Fatal("You must set a non-empty -root pointer key")
+	} else if s.ReadOnly && s.AutoFlush > 0 {
+		log.Fatal("You may not enable -auto-flush with -read-only")
+	}
+
+	// Load configuration file.
+	s.Config, err = config.Load(config.Path())
+	if err != nil {
+		log.Fatalf("Loading configuration: %v", err)
+	}
+	if s.StoreSpec != "" {
+		s.Config.DefaultStore = s.StoreSpec
+	} else {
+		// Copy the default so it shows up in /status.
+		s.StoreSpec = s.Config.DefaultStore
+	}
+	if s.DebugLog {
+		s.Config.EnableDebugLogging = true
+		fuse.Debug = func(arg any) { log.Printf("FUSE: %v", arg) }
+	}
+
+	// Open blob store.
+	s.Store, err = s.Config.OpenStore()
+	if err != nil {
+		log.Fatalf("Opening blob store: %v", err)
+	}
+
+	// Load the root of the filesystem.
+	pi, err := config.OpenPath(ctx, s.Store, s.RootKey)
+	if err != nil {
+		log.Fatalf("Loading root path: %v", err)
+	}
+	s.Path.Store(pi)
+	if pi.Root != nil {
+		log.Printf("Loaded filesystem from %q (%x)", pi.RootKey, pi.FileKey)
+		if pi.Root.Description != "" {
+			log.Printf("| Description: %q", pi.Root.Description)
+		}
+	} else {
+		log.Printf("Loaded filesystem at %x (no root pointer)", pi.FileKey)
+	}
+
+	s.Status = http.NewServeMux()
+	s.Status.HandleFunc("/status", s.handleStatus)
+	s.Status.HandleFunc("/flush", s.handleStatus)
+	s.Status.HandleFunc("/root/", s.handleRoot)
+}
+
+// Mount establishes a connection for the filesystem mount point and prepares
+// the filesystem root for service.
+func (s *Service) Mount() error {
+	opts := s.MountOptions
+	if s.ReadOnly {
+		opts = append(opts, fuse.ReadOnly())
+	}
+
+	var err error
+	s.Conn, err = fuse.Mount(s.MountPath, opts...)
+	if err != nil {
+		return err
+	}
+
+	s.FileServer = fs.New(s.Conn, nil)
+	s.FS = ffuse.New(s.Path.Load().File, s.FileServer, &s.Options)
+	return nil
+}
+
+// Run starts the file service and runs until it exits or ctx ends.
+func (s *Service) Run(ctx context.Context) error {
+	// Start the server running and wait for the connection to be ready.
+	done := make(chan error, 1)
+	go func() {
+		defer close(done)
+		done <- s.FileServer.Serve(s.FS)
+	}()
+
+	<-s.Conn.Ready
+	if err := s.Conn.MountError; err != nil {
+		s.Conn.Close()
+		return err
+	}
+
+	// If we are supposed to auto-flush, set up a task fto do that now.
+	if s.AutoFlush > 0 {
+		log.Printf("Enabling auto-flush every %v", s.AutoFlush)
+		go s.autoFlush(ctx, s.AutoFlush)
+	}
+
+	select {
+	case err := <-done:
+		return err
+
+	case <-ctx.Done():
+		log.Printf("Unmounting %q", s.MountPath)
+		if err := fuse.Unmount(s.MountPath); err != nil {
+			log.Printf("WARNING: Unmount failed: %v", err)
+		}
+		return errors.New("terminated by signal")
+	}
+}
+
+// Shutdown closes the FUSE connection and flushes any unsaved data back out to
+// the blob store.
+func (s *Service) Shutdown(ctx context.Context) {
+	if err := s.Conn.Close(); err != nil {
+		log.Printf("WARNING: closing fuse connection failed: %v", err)
+	} else {
+		log.Print("Closed fuse connection")
+	}
+	if !s.ReadOnly {
+		pi := s.Path.Swap(nil)
+		rk, err := pi.Flush(ctx)
+		if err != nil {
+			blob.CloseStore(ctx, s.Store)
+			log.Fatalf("Flushing file data: %v", err)
+		}
+		fmt.Printf("%x\n", rk)
+	}
+	blob.CloseStore(ctx, s.Store)
+}
+
+func (s *Service) autoFlush(ctx context.Context, d time.Duration) {
+	t := time.NewTicker(d)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Print("Stopping auto-flush routine")
+			return
+		case <-t.C:
+			oldKey, newKey, err := s.flushRoot(ctx)
+			if err != nil {
+				log.Printf("WARNING: Error flushing root: %v", err)
+			} else if newKey != oldKey {
+				log.Printf("Root flushed, storage key is now %x", newKey)
+			}
+		}
+	}
+}
+
+func (s *Service) flushRoot(ctx context.Context) (oldKey, newKey string, err error) {
+	// We need to lock out filesystem operations while we do this, since it may
+	// update state deeper inside the tree.
+	s.FS.WithRoot(func(_ *file.File) {
+		pi := s.Path.Load()
+		if pi == nil {
+			err = errors.New("current path not found")
+			return
+		}
+		oldKey = pi.Root.FileKey
+		newKey, err = pi.Flush(ctx)
+	})
+	return
+}
+
+func (s *Service) handleStatus(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	doFlush := req.URL.Path == "/flush"
+
+	var oldKey, newKey string
+	if doFlush {
+		ok, nk, err := s.flushRoot(req.Context())
+		if err != nil {
+			log.Printf("WARNING: Error flushing root: %v", err)
+		} else if ok != nk {
+			oldKey = ok
+		}
+		newKey = nk
+	} else if pi := s.Path.Load(); pi != nil {
+		newKey = pi.FileKey
+	}
+
+	var autoFlush string
+	if s.AutoFlush > 0 {
+		autoFlush = s.AutoFlush.Round(time.Second).String()
+	}
+	writeJSON(w, http.StatusOK, statusReply{
+		MountPath:  s.MountPath,
+		RootKey:    s.RootKey,
+		Store:      s.StoreSpec,
+		ReadOnly:   s.ReadOnly,
+		AutoFlush:  autoFlush,
+		OldKey:     []byte(oldKey),
+		StorageKey: []byte(newKey),
+	})
+}
+
+type statusReply struct {
+	MountPath  string `json:"mountPath"`
+	RootKey    string `json:"rootKey"`
+	Store      string `json:"store"`
+	ReadOnly   bool   `json:"readOnly"`
+	AutoFlush  string `json:"autoFlush,omitempty"`
+	OldKey     []byte `json:"oldKey,omitempty"`
+	StorageKey []byte `json:"storageKey"`
+}
+
+func (s *Service) handleRoot(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "PUT" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	newRoot := strings.TrimPrefix(req.URL.Path, "/root/")
+	if newRoot == "" {
+		writeJSON(w, http.StatusBadRequest, "missing new root pointer")
+		return
+	}
+	pi, err := config.OpenPath(req.Context(), s.Store, newRoot)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, struct {
+			K string `json:"rootKey"`
+			E string `json:"error"`
+		}{K: newRoot, E: err.Error()})
+		return
+	}
+	s.Path.Store(pi)
+	s.FS.Update(pi.File)
+	log.Printf("Filesystem root updated to %q (%x)", newRoot, pi.FileKey)
+	writeJSON(w, http.StatusOK, struct {
+		K string `json:"rootKey"`
+		S []byte `json:"storageKey"`
+	}{K: newRoot, S: []byte(pi.FileKey)})
+}
+
+func writeJSON(w http.ResponseWriter, code int, value any) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(data)
+}

--- a/cmd/ffuse/service.go
+++ b/cmd/ffuse/service.go
@@ -47,8 +47,6 @@ type Service struct {
 // Init checks the settings, and loads the initial filesystem state from the
 // specified blob store. It terminates the process if any of these steps fail.
 func (s *Service) Init(ctx context.Context) {
-	var err error
-
 	// Check flags for consistency.
 	if s.MountPath == "" {
 		log.Fatal("You must set a non-empty -mount path")
@@ -57,6 +55,8 @@ func (s *Service) Init(ctx context.Context) {
 	} else if s.ReadOnly && s.AutoFlush > 0 {
 		log.Fatal("You may not enable -auto-flush with -read-only")
 	}
+
+	var err error
 
 	// Load configuration file.
 	s.Config, err = config.Load(config.Path())


### PR DESCRIPTION
- Move filesystem state to a separate Service type.
- Move setup, run, and teardown flow to Service methods.
- Add optional HTTP endpoints to replace the signals.
- Clean up some bugs in invalidation plumbing.
- Simplify signal handling.